### PR TITLE
Added non-american spelling alias export.

### DIFF
--- a/src/extensible-duck.js
+++ b/src/extensible-duck.js
@@ -103,6 +103,9 @@ export function constructLocalized(selectors) {
   }
 }
 
+// An alias for those who do not use the above spelling.
+export { constructLocalized as constructLocalised }
+
 /**
  * Helper utility to assist in composing the selectors.
  * Previously defined selectors can be used to derive future selectors.


### PR DESCRIPTION
Added this because I ~~have OCD~~ constantly used `constructLocalised` instead of `constructLocalized`, I'm sure other developers may find this addition handy.