### PR TITLE
storePath should allow constructLocalized to provide local duck state within deeply nested redux state trees

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ const { namespace, store, types, consts, initialState, creators } = options
 |--------------|---------------------------------------------------------|--------------------------------|---------------------------------------------|
 | namespace    | Used as a prefix for the types                          | String                         | `'my-app'`                                  |
 | store        | Used as a prefix for the types and as a redux state key | String                         | `'widgets'`                                 |
+| storePath    | Object path of the store from root infinal redux state.  Defaults to the [duck.store] value.  Can be used to define duck store location in nested state  | String                         | `'foo.bar'`                                 |
 | types        | List of action types                                    | Array                          | `[ 'CREATE', 'UPDATE' ]`                    |
 | consts       | Constants you may need to declare                       | Object of Arrays               | `{ statuses: [ 'LOADING', 'LOADED' ] }`     |
 | initialState | State passed to the reducer when the state is undefined | Anything                       | `{}`                                        |
@@ -83,6 +84,7 @@ const { namespace, store, types, consts, initialState, creators } = options
 ### Duck Accessors
 
  * duck.store
+ * duck.storePath
  * duck.reducer
  * duck.creators
  * duck.selectors
@@ -91,7 +93,7 @@ const { namespace, store, types, consts, initialState, creators } = options
 
 ### Helper functions
 
- * **constructLocalized(selectors)**: maps selectors syntax from `(globalStore) => selectorBody` into `(localStore, globalStore) => selectorBody`. `localStore` is derived from `globalStore` on every selector execution using `duck.storage` key. Use to simplify selectors syntax when used in tandem with reduxes' `combineReducers` to bind the duck to a dedicated state part ([example](#creating-ducks-with-selectors)).
+ * **constructLocalized(selectors)**: maps selectors syntax from `(globalStore) => selectorBody` into `(localStore, globalStore) => selectorBody`. `localStore` is derived from `globalStore` on every selector execution using `duck.storage` key. Use to simplify selectors syntax when used in tandem with reduxes' `combineReducers` to bind the duck to a dedicated state part ([example](#creating-ducks-with-selectors)).  If defined will use the duck.storePath value to determine the localized state in deeply nested redux state trees.
 
 ### Defining the Reducer
 

--- a/test/unit/extensible-duck.js
+++ b/test/unit/extensible-duck.js
@@ -99,6 +99,41 @@ describe('Duck', () => {
       expect(duck.selectors.countPlanets(store)).to.eql(4)
       expect(duck.selectors.countObjects(store)).to.eql(7)
     })
+    it('can construct localized state of deep nested duck reference', () => {
+      const planetsState = {
+        planets: [
+          'mercury',
+          'wenus',
+          'earth',
+          'mars',
+        ]
+      }
+      const duck = new Duck({
+        store: 'box',
+        storePath: 'foo.bar',
+        initialState: {
+          items: [
+            'chocolate',
+            'muffin',
+            'candy',
+          ]
+        },
+        selectors: constructLocalized({
+          countSweets: (localState) => localState.items.length,
+          countPlanets: (localState, globalState) => globalState.planets.length,
+        })
+      })
+      const store = {
+        ...planetsState,
+        foo: {
+          bar: {
+            [duck.store]: duck.initialState,
+          }
+        }
+      }
+      expect(duck.selectors.countSweets(store)).to.eql(3)
+      expect(duck.selectors.countPlanets(store)).to.eql(4)
+    })
     it('works with reselect', () => {
       const duck = new Duck({
         selectors: {


### PR DESCRIPTION
Fixes #22 

I have added the option ```storePath```.

It is optional and will default to the defined ```duck.store``` option if not defined.

It is used within constructLocalized to determine the final location of the duck store instance.  It will allow duck's stores to be  bound deeply within the redux state as such: 

```
{
        foo: {
          bar: {
            [duck.store]: duck.store,
       }
}
```

const myDuck = new Duck({ store: 'myDuck', storePath: 'foo.bar' });

Tests and documentation have been updated accordingly